### PR TITLE
Fixed : Improved downloading of requirements.txt

### DIFF
--- a/honeyscanner/honeypots/base_honeypot.py
+++ b/honeyscanner/honeypots/base_honeypot.py
@@ -1,5 +1,5 @@
 from typing import TypeAlias
-
+import requests
 
 Versions: TypeAlias = list[dict[str, str]]
 
@@ -46,3 +46,28 @@ class BaseHoneypot:
 
     def _set_versions_list(self) -> Versions:
         raise NotImplementedError(self._impl_err)
+    
+    def get_requirements(self,repo):
+        #repos = ['cowrie/cowrie','mushorg/conpot','DinoTools/dionaea','desaster/kippo']
+        headers = {
+            "X-GitHub-Api-Version": "2022-11-28",
+            "Accept": "application/vnd.github.v3+json"
+        }
+        response_ver = requests.get(f'https://api.github.com/repos/{repo}/tags',headers=headers).json()
+
+        versions = []
+        for el in response_ver:
+            versions.append(el["name"])
+
+        return_data = []
+        for version in versions:
+            data = {
+                "version" :'',
+                "requirements_url" : ''
+            }
+            data["version"] = version
+            data["requirements_url"] = f'https://raw.githubusercontent.com/{repo}/{version}/requirements.txt'
+
+            return_data.append(data)
+        
+        return return_data

--- a/honeyscanner/honeypots/conpot.py
+++ b/honeyscanner/honeypots/conpot.py
@@ -42,53 +42,8 @@ class Conpot(BaseHoneypot):
         Returns:
             list[dict]: List of versions of the Conpot Honeypot
         """
-        return [
-            {
-                "version": "0.6.0",
-                "requirements_url": "https://raw.githubusercontent.com/mushorg/conpot/Release_0.6.0/requirements.txt",
-            },
-            {
-                "version": "0.5.2",
-                "requirements_url": "https://raw.githubusercontent.com/mushorg/conpot/Release_0.5.2/requirements.txt",
-            },
-            {
-                "version": "0.5.1",
-                "requirements_url": "https://raw.githubusercontent.com/mushorg/conpot/Release_0.5.1/requirements.txt",
-            },
-            {
-                "version": "0.5.0",
-                "requirements_url": "https://raw.githubusercontent.com/mushorg/conpot/Release_0.5.0/requirements.txt",
-            },
-            {
-                "version": "0.4.0",
-                "requirements_url": "https://raw.githubusercontent.com/mushorg/conpot/Release_0.4.0/requirements.txt",
-            },
-            {
-                "version": "0.3.1",
-                "requirements_url": "https://raw.githubusercontent.com/mushorg/conpot/Release_0.3.1/requirements.txt",
-            },
-            {
-                "version": "0.3.0",
-                "requirements_url": "https://raw.githubusercontent.com/mushorg/conpot/Release_0.3.0/requirements.txt",
-            },
-            # NO Release_ used in front of the version from here on
-            {
-                "version": "0.2.2",
-                "requirements_url": "https://raw.githubusercontent.com/mushorg/conpot/0.2.2/requirements.txt",
-            },
-            {
-                "version": "0.2.2",
-                "requirements_url": "https://raw.githubusercontent.com/mushorg/conpot/0.2.2/requirements.txt",
-            },
-            {
-                "version": "0.2.1",
-                "requirements_url": "https://raw.githubusercontent.com/mushorg/conpot/0.2.1/requirements.txt",
-            },
-            {
-                "version": "0.2",
-                "requirements_url": "https://raw.githubusercontent.com/mushorg/conpot/0.2/requirements.txt",
-            }
-        ]
+        version_list = super().get_requirements('mushorg/conpot')
+        return version_list
 
     def _set_owner(self) -> str:
         """

--- a/honeyscanner/honeypots/cowrie.py
+++ b/honeyscanner/honeypots/cowrie.py
@@ -36,7 +36,7 @@ class Cowrie(BaseHoneypot):
         Returns:
             str: The version of the Cowire Honeypot
         """
-        if version in ["2.1.0", "2.4.0", "2.5.0"]:
+        if version in ["2.1.0", "2.4.0", "2.5.0","2.6.1"]: #-----------
             return 'v' + version
         else:
             return version
@@ -57,28 +57,8 @@ class Cowrie(BaseHoneypot):
         Returns:
             list[dict]: List of versions of the Cowire Honeypot
         """
-        return [
-            {
-                "version": "1.5.1",
-                "requirements_url": "https://raw.githubusercontent.com/cowrie/cowrie/1.5.1/requirements.txt",
-            },
-            {
-                "version": "1.5.3",
-                "requirements_url": "https://raw.githubusercontent.com/cowrie/cowrie/1.5.3/requirements.txt",
-            },
-            {
-                "version": "v2.1.0",
-                "requirements_url": "https://raw.githubusercontent.com/cowrie/cowrie/v2.1.0/requirements.txt",
-            },
-            {
-                "version": "v2.4.0",
-                "requirements_url": "https://raw.githubusercontent.com/cowrie/cowrie/v2.4.0/requirements.txt",
-            },
-            {
-                "version": "v2.5.0",
-                "requirements_url": "https://raw.githubusercontent.com/cowrie/cowrie/v2.5.0/requirements.txt",
-            }
-        ]
+        version_list = super().get_requirements('cowrie/cowrie')
+        return version_list
 
     def _set_owner(self) -> str:
         """
@@ -88,3 +68,4 @@ class Cowrie(BaseHoneypot):
             str: The owner of the Cowire Honeypot
         """
         return "cowrie"
+    


### PR DESCRIPTION
in reference to the issue #45 

This PR updates the `honeyscanner/honeypots/base_honeypot.py`

### Changes made:
- The versions and requirements.txt were hard coded, not covering latest versions released which is not scalable enough
- A new function `get_requirements` is added to the `BaseHoneypot` class which retrieves the latest version and `requirements.txt` file of a honeypot
- `cowrie.py` and `conpot.py` were updated as they have `requirements.txt` on their GitHub repo.

The error has been fixed and the code has been made more scalable