### PR TITLE
Feature : Added argument to choose the attack

### DIFF
--- a/honeyscanner/active_attacks/attack_orchestrator.py
+++ b/honeyscanner/active_attacks/attack_orchestrator.py
@@ -30,6 +30,35 @@ class AttackOrchestrator:
         self.successful_attacks: int = 0
         self.results: AttackResults
 
+    #individual attacks
+    def run_fuzzing(self) -> None:
+        """
+        Runs Fuzzing attack on the specified honeypot.
+        """
+        result = [self.attacks[0].run_attack()]
+        if result[0]:
+            self.successful_attacks += 1
+        self.results = result
+
+    def run_tarbomb(self) -> None:
+        """
+        Runs TarBomb attack on the specified honeypot.
+        """
+        result = [self.attacks[1].run_attack()]
+        if result[0]:
+            self.successful_attacks += 1
+        self.results = result
+
+    def run_dos(self) -> None:
+        """
+        Runs DoS attack on the specified honeypot.
+        """
+        result = [self.attacks[2].run_attack()]
+        if result[0]:
+            self.successful_attacks += 1
+        self.results = result
+
+    #all attacks
     def run_attacks(self) -> None:
         """
         Runs all attacks that can be ran on the specified honeypot.

--- a/honeyscanner/core.py
+++ b/honeyscanner/core.py
@@ -85,7 +85,72 @@ class Honeyscanner:
                                                  honeypot_ports,
                                                  honeypot_username,
                                                  honeypot_password)
+    #Passive Attacks
+    def run_vulnanalyzer(self) -> None:
+        """
+        Run VulnAnalyzer on the Honeypot and save the attack findings.
+        """
+        self.passive_attack_orchestrator.run_vulnanalyzer()
+        self.passive_attack_results, self.recommendations = (
+            self.passive_attack_orchestrator.generate_report()
+        )
+        self.active_attack_results = None
 
+    def run_statichoney(self) -> None:
+        """
+        Run StaticHoney on the Honeypot and save the attack findings.
+        """
+        self.passive_attack_orchestrator.run_statichoney()
+        self.passive_attack_results, self.recommendations = (
+            self.passive_attack_orchestrator.generate_report()
+        )
+        self.active_attack_results = None
+    
+    def run_trivyscanner(self) -> None:
+        """
+        Run TrivyScanner on the Honeypot and save the attack findings.
+        """
+        self.passive_attack_orchestrator.run_trivyscanner()
+        self.passive_attack_results, self.recommendations = (
+            self.passive_attack_orchestrator.generate_report()
+        )
+        self.active_attack_results = None
+
+    #Active attacks
+    def run_fuzzing(self) -> None:
+        """
+        Run Fuzzing on the Honeypot and save the attack findings.
+        """
+        self.active_attack_orchestrator.run_fuzzing()
+        self.active_attack_results: tuple[str, int, int] = (
+            self.active_attack_orchestrator.generate_report()
+        )
+        self.passive_attack_results = None
+        self.recommendations = None
+
+    def run_tarbomb(self) -> None:
+        """
+        Run TarBomb on the Honeypot and save the attack findings.
+        """
+        self.active_attack_orchestrator.run_tarbomb()
+        self.active_attack_results: tuple[str, int, int] = (
+            self.active_attack_orchestrator.generate_report()
+        )
+        self.passive_attack_results = None
+        self.recommendations = None
+
+    def run_dos(self) -> None:
+        """
+        Run DoS on the Honeypot and save the attack findings.
+        """
+        self.active_attack_orchestrator.run_dos()
+        self.active_attack_results: tuple[str, int, int] = (
+            self.active_attack_orchestrator.generate_report()
+        )
+        self.passive_attack_results = None
+        self.recommendations = None
+
+    #for all attacks 
     def run_all_attacks(self) -> None:
         """
         Run all attacks on the Honeypot and save the attack findings.
@@ -106,6 +171,6 @@ class Honeyscanner:
         Generate the evaluation report for the Honeypot off of
         the attack results.
         """
-        self.report_generator.generate(list(self.recommendations.values()),
-                                       self.passive_attack_results,
-                                       self.active_attack_results)
+        self.report_generator.generate(list(self.recommendations.values()) if self.recommendations else [],
+                                    self.passive_attack_results,
+                                    self.active_attack_results)

--- a/honeyscanner/main.py
+++ b/honeyscanner/main.py
@@ -30,7 +30,8 @@ def parse_arguments() -> argparse.Namespace:
         argparse.Namespace: Parsed arguments object.
     """
     parser = argparse.ArgumentParser(
-        description="Honeyscanner: A vulnerability analyzer for honeypots"
+        description="Honeyscanner: A vulnerability analyzer for honeypots",
+        formatter_class=argparse.RawTextHelpFormatter
     )
     parser.add_argument(
         "--target-ip",
@@ -52,6 +53,13 @@ def parse_arguments() -> argparse.Namespace:
         default="",
         help="The password to connect to the honeypot",
     )
+    parser.add_argument(
+        "--attack",
+        type=str,
+        required=False,
+        default="all",
+        help="The attack to perform on the honeypot.\nVulnAnalyzer:vulnanalyze\nStaticHoney:statichoney\nTrivyScanner:trivyscanner\nDoS:dos\nFuzzing:fuzz\nTarBomb:tarbomb"
+    )
     return parser.parse_args()
 
 
@@ -63,11 +71,30 @@ def main() -> None:
     print(ascii_art_honeyscanner())
     detector = HoneypotDetector(args.target_ip)
     honeyscanner = detector.detect_honeypot(args.username, args.password)
+
+    #attack to perform
+    attack = args.attack
+
     if not honeyscanner:
         return
 
     try:
-        honeyscanner.run_all_attacks()
+        if attack=="vulnanalyze":
+            honeyscanner.run_vulnanalyzer()
+        elif attack=="statichoney":
+            honeyscanner.run_statichoney()
+        elif attack=="trivyscanner":
+            honeyscanner.run_trivyscanner()
+        elif attack=="dos":
+            honeyscanner.run_dos()
+        elif attack=="fuzz":
+            honeyscanner.run_fuzzing()
+        elif attack=="tarbomb":
+            honeyscanner.run_tarbomb()
+        elif attack=="all":
+            honeyscanner.run_all_attacks()
+        else:
+            honeyscanner.run_all_attacks()
     except Exception:
         issue: str = traceback.format_exc()
         print(f"An error occurred during the attacks: {issue}")

--- a/honeyscanner/report_generator.py
+++ b/honeyscanner/report_generator.py
@@ -54,11 +54,41 @@ class ReportGenerator:
         """
         date: str = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
         report_date: str = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        total_attacks: int = active_results[1]
+        """total_attacks: int = active_results[1]
         attack_success: int = active_results[2]
-        success_rate: str = f"{(attack_success / total_attacks) * 100:.2f}%"
+        success_rate: str = f"{(attack_success / total_attacks) * 100:.2f}%
+        """
+        ########
+        total_attacks: int = active_results[1] if active_results else 0
+        attack_success: int = active_results[2] if active_results else 0
+        success_rate: str = f"{(attack_success / total_attacks) * 100:.2f}%" if total_attacks > 0 else "N/A"
+
         print("Generating report...")
-        report: str = self.template.render(
+
+        # Build the context dictionary
+        context = {
+            "name": self.honeypot.name,
+            "version": self.honeypot.version,
+            "ip": self.honeypot.ip,
+            "port": self.honeypot.ports,
+            "date": report_date,
+            "all_cves": self.count_all_cves(),
+            "success": attack_success,
+            "failed": total_attacks - attack_success,
+            "rating":success_rate
+        }
+
+        # Conditionally add active_results and passive_results
+        if active_results:
+            context["active_results"] = active_results[0]
+        if passive_results:
+            context["passive_results"] = passive_results
+            context["recommendations"] = recommendations
+
+        report: str = self.template.render(**context)
+
+        #print("Generating report...")
+        """report: str = self.template.render(
                         name=self.honeypot.name,
                         version=self.honeypot.version,
                         ip=self.honeypot.ip,
@@ -70,7 +100,7 @@ class ReportGenerator:
                         success=attack_success,
                         failed=total_attacks - attack_success,
                         rating=success_rate,
-                        recommendations=recommendations)
+                        recommendations=recommendations)"""
         new_report_path: Path = self.report_path / f"report_{date}.txt"
         new_report_path.write_text(report)
         print(f"Report generated successfully at {new_report_path}")


### PR DESCRIPTION
Closes #47 

# Changes made:
- new argument `--attack` was added to the `arg parser` 
- the user can input the attack which he wants to execute or execute all the attacks at once.
- improved the report generation process for `passive` and `active` attacks

![honey](https://github.com/user-attachments/assets/e14c4e09-87f2-40e1-ab95-8402bb19997e)

# Argument options
run the script using : `python3.10 main.py --target-ip 127.0.0.1 --attack ATTACK_NAME`
Options for ATTACK_NAME are:
- vulnanalyze
- statichoney
- trivyscanner
- fuzz
- tarbomb
- dos
- all
**not adding the `attack` parameter will execute all the attacks at once**