### PR TITLE
Added Support for Glastopf Honeypot

### DIFF
--- a/honeyscanner/active_attacks/attack_orchestrator.py
+++ b/honeyscanner/active_attacks/attack_orchestrator.py
@@ -20,6 +20,11 @@ class AttackOrchestrator:
             self.attacks = [
                 DoS(honeypot)
             ]
+        elif honeypot.name == "glastopf":
+            self.attacks = [
+                Fuzzing(honeypot),
+                DoS(honeypot)
+            ]
         else:
             self.attacks = [
                 Fuzzing(honeypot),

--- a/honeyscanner/core.py
+++ b/honeyscanner/core.py
@@ -1,5 +1,5 @@
 from active_attacks import AttackOrchestrator as ActiveAttackOrchestrator
-from honeypots import BaseHoneypot, Cowrie, Conpot, Dionaea, Kippo
+from honeypots import BaseHoneypot, Cowrie, Conpot, Dionaea, Kippo,Glastopf
 from passive_attacks import AttackOrchestrator as PassiveAttackOrchestrator
 from report_generator import ReportGenerator
 
@@ -74,7 +74,8 @@ class Honeyscanner:
             'cowrie': Cowrie,
             'kippo': Kippo,
             'dionaea': Dionaea,
-            'conpot': Conpot
+            'conpot': Conpot,
+            'glastopf':Glastopf
         }
         if honeypot_type not in honeypot_class_map:
             supported_honeypots: str = ', '.join(honeypot_class_map.keys())

--- a/honeyscanner/honeypots/__init__.py
+++ b/honeyscanner/honeypots/__init__.py
@@ -3,3 +3,4 @@ from .conpot import Conpot
 from .cowrie import Cowrie
 from .dionaea import Dionaea
 from .kippo import Kippo
+from .glastopf import Glastopf

--- a/honeyscanner/honeypots/glastopf.py
+++ b/honeyscanner/honeypots/glastopf.py
@@ -1,0 +1,96 @@
+from .base_honeypot import BaseHoneypot, Versions
+
+
+class Glastopf(BaseHoneypot):
+    def __init__(self,
+                 version: str,
+                 ip: str,
+                 ports: set[int],
+                 username: str | None = 'root',
+                 password: str | None = '12345') -> None:
+        """
+        Initializes a new instance of the Glastopf Honeypot object.
+
+        Args:
+            version (str): The version of the Glastopf Honeypot.
+            ip (str): The IP address of the Honeypot.
+            port (int): The port number of the Honeypot.
+            username (str, optional): The username to authenticate with.
+                                      Defaults to 'root'.
+            password (str, optional): The password to authenticate with.
+                                      Defaults to '12345'.
+        """
+        if username is None:
+            username = 'root'
+        if password is None:
+            password = '1234'
+        super().__init__("glastopf", version, ip, ports, username, password)
+
+    def _set_version(self, version: str) -> str:
+        """
+        Sets the version of the running Glastopf Honeypot
+
+        Args:
+            version (str): User inputted version number
+
+        Returns:
+            str: The version of the Cowire Honeypot
+        """
+        if version in ["3.0.0", "3.0.6", "3.0.7","3.0.8","3.1","3.1.1","3.1.2"]:
+            return version
+
+    def _set_source_code_url(self) -> str:
+        """
+        Sets the source code URL of the running Glastopf Honeypot
+
+        Returns:
+            str: The source code URL of the Glastopf Honeypot
+        """
+        return "https://github.com/mushorg/glastopf/archive/refs/tags"
+
+    def _set_versions_list(self) -> Versions:
+        """
+        Sets the list of versions of the Glastopf Honeypot
+
+        Returns:
+            list[dict]: List of versions of the Glastopf Honeypot
+        """
+        return [
+            {
+                "version": "3.0.0",
+                "requirements_url": "https://raw.githubusercontent.com/mushorg/glastopf/refs/tags/3.0.0/requirements.txt",
+            },
+            {
+                "version": "3.0.6",
+                "requirements_url": "https://raw.githubusercontent.com/mushorg/glastopf/refs/tags/3.0.6/requirements.txt",
+            },
+            {
+                "version": "3.0.7",
+                "requirements_url": "https://raw.githubusercontent.com/mushorg/glastopf/refs/tags/3.0.7/requirements.txt",
+            },
+            {
+                "version": "3.0.8",
+                "requirements_url": "https://raw.githubusercontent.com/mushorg/glastopf/refs/tags/3.0.8/requirements.txt",
+            },
+            {
+                "version": "3.1",
+                "requirements_url": "https://raw.githubusercontent.com/mushorg/glastopf/refs/tags/3.1/requirements.txt",
+            },
+            {
+                "version": "3.1.1",
+                "requirements_url": "https://raw.githubusercontent.com/mushorg/glastopf/refs/tags/3.1.1/requirements.txt",
+            },
+            {
+                "version": "3.1.2",
+                "requirements_url": "https://raw.githubusercontent.com/mushorg/glastopf/refs/tags/3.1.2/requirements.txt",
+            }
+        ]
+
+    def _set_owner(self) -> str:
+        """
+        Sets the owner of the Glastopf Honeypot
+
+        Returns:
+            str: The owner of the Glastopf Honeypot
+        """
+        return "mushorg"

--- a/honeyscanner/passive_attacks/honeypot_detector/detect_honeypot.py
+++ b/honeyscanner/passive_attacks/honeypot_detector/detect_honeypot.py
@@ -145,6 +145,8 @@ class HoneypotDetector:
             return "0.11.0"
         elif honeypot == "conpot":
             url = "https://api.github.com/repos/mushorg/conpot/releases/latest"
+        elif honeypot == "glastopf":
+            url = "https://api.github.com/repos/mushorg/glastopf/releases/latest"
 
         response = requests.get(url)
 
@@ -232,6 +234,7 @@ class HoneypotDetector:
             "cowrie": 0,
             "dionaea": 0,
             "kippo": 0,
+            "glastopf":0,
             "unsupported": 0
         }
 

--- a/honeyscanner/passive_attacks/honeypot_detector/signatures.yaml
+++ b/honeyscanner/passive_attacks/honeypot_detector/signatures.yaml
@@ -4,6 +4,12 @@
       - input: "USER root\r\nPASS \r\n"
         output: "220 DiskStation FTP server ready.\r\n"
 
+80:
+  - name: "glastopf"
+    steps:
+      - input: "GET / HTTP/1.1\nHost: 127.0.0.1\n\n"
+        output: "Server: Apache/2.0.48"
+
 102:
   - name: "conpot"
     steps:


### PR DESCRIPTION
## Changes made
- Added new honeypot `Glastopf`
- updated `signatures.yaml` to take `glastopf` into account
- updated `vuln_analyzer` to take care of `requirements.txt` when they contain packages with no versions, or `>=` sign , for example :
```
pyopenssl
sqlalchemy>=0.7.0
lxml
beautifulsoup>=3.2.0
numpy>=1.6.1
#scipy>=0.9.0
requests>=1.0.0
cssselect>=0.7.0
pymongo>=2.4
chardet
scikit_learn>=0.13.0
```
- Glastopf works on port `80` so `TarBomb` attack doesn't work on it

## How to test
Setup Docker Image:
- Pull the Image: `docker pull decepot/glastopf`
- Run the Honeypot: `docker run -d -p 80:80 decepot/glastopf`
- Check Logs: `docker logs container_id`

Run Honeyscanner
`python3.10 main.py --target-ip 127.0.0.1`

## Scan Results
[scan_results.txt.txt](https://github.com/user-attachments/files/19396345/scan_results.txt.txt)

