### PR TITLE
Fix IPv6 handling: preserve ':' in target IP sanitization

### DIFF
--- a/honeyscanner/main.py
+++ b/honeyscanner/main.py
@@ -20,7 +20,7 @@ def sanitize_string(s: str) -> str:
     """
     s = s.strip()
     s = s.lower()
-    s = re.sub(r'[^a-z0-9._\- ]', '', s)
+    s = re.sub(r'[^a-z0-9:._\- ]', '', s)
     return s
 
 


### PR DESCRIPTION
## 🐛 Issue

The current input sanitization removes `:` characters from the target IP, which breaks valid IPv6 addresses.

### Example

Input:
2001:db8::1

After sanitization:
2001db81

This results in an invalid IP and causes incorrect behavior during honeypot detection.

---

## ✅ Fix

Updated the regex in `sanitize_string` to allow `:`:

```python
s = re.sub(r'[^a-z0-9:._\- ]', '', s)
```

Closes #53